### PR TITLE
Fix Vercel config to build server.js

### DIFF
--- a/context/vercel.json
+++ b/context/vercel.json
@@ -1,10 +1,10 @@
 {
   "version": 2,
-  "builds": [{ "src": "./index.js", "use": "@vercel/node" }],
+  "builds": [{ "src": "./server.js", "use": "@vercel/node" }],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/index.js"
+      "dest": "/server.js"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update Vercel `builds` src to `./server.js`
- route all requests to `/server.js`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685323f5ca5883219f0bc72a4049f25f